### PR TITLE
Retry command as W3C when MicrosoftWebDriver returns Unknown Error

### DIFF
--- a/lib/helpers/utilities.js
+++ b/lib/helpers/utilities.js
@@ -74,6 +74,25 @@ export function isUnknownCommand (err) {
 }
 
 /**
+ * Checks if the error message is an unknown error
+ * https://w3c.github.io/webdriver/#dfn-unknown-error
+ * @param {Error} err
+ * @return {Boolean} Whether the error message is an "Unknown Error"
+ */
+export function isUnknownError (err) {
+    if (!err || typeof err !== 'object') {
+        return false
+    }
+
+    if (err.message.match(/Unknown error/i)
+    ) {
+        return true
+    }
+
+    return false
+}
+
+/**
  * Prepare the hostname to properly use IPv6 address
  * @param {string} hostname
  * @returns {string}

--- a/lib/helpers/utilities.js
+++ b/lib/helpers/utilities.js
@@ -84,8 +84,7 @@ export function isUnknownError (err) {
         return false
     }
 
-    if (err.message.match(/Unknown error/i)
-    ) {
+    if (err.message.match(/Unknown error/i)) {
         return true
     }
 

--- a/lib/protocol/execute.js
+++ b/lib/protocol/execute.js
@@ -36,7 +36,7 @@
  */
 
 import { ProtocolError } from '../utils/ErrorHandler'
-import { isUnknownCommand } from '../helpers/utilities'
+import { isUnknownCommand, isUnknownError } from '../helpers/utilities'
 
 export default function execute (...args) {
     let script = args.shift()
@@ -59,8 +59,11 @@ export default function execute (...args) {
     return this.requestHandler.create('/session/:sessionId/execute', { script, args }).catch((err) => {
         /**
          * jsonwire command not supported try webdriver endpoint
+         * Note: MicrosoftWebDriver returns "UnknownError" when receiving
+         *  a jsonwire command in W3C Mode
+         *  https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/19917561/
          */
-        if (isUnknownCommand(err)) {
+        if (isUnknownCommand(err) || isUnknownError(err)) {
             return this.requestHandler.create('/session/:sessionId/execute/sync', { script, args })
         }
 

--- a/test/spec/unit/utilities.js
+++ b/test/spec/unit/utilities.js
@@ -1,4 +1,4 @@
-import { isSuccessfulResponse, isUnknownCommand, formatHostname } from '../../../lib/helpers/utilities'
+import { isSuccessfulResponse, isUnknownCommand, isUnknownError, formatHostname } from '../../../lib/helpers/utilities'
 
 describe('utilities', () => {
     describe('isSuccessfulResponse', () => {
@@ -118,6 +118,29 @@ describe('utilities', () => {
                     type: 'UnknownError',
                     message: 'An unknown server-side error occurred while processing the command.'
                 }
+            })).to.be.equal(true)
+        })
+    })
+
+    describe('isUnknownError', () => {
+        it('no valid error', () => {
+            expect(isUnknownError()).to.be.equal(false)
+            expect(isUnknownError('foobar')).to.be.equal(false)
+        })
+
+        it('should recognise unknown command when using driver', () => {
+            expect(isUnknownError({
+                message: 'Unknown error'
+            })).to.be.equal(true)
+        })
+
+        it('should recognise unknown command as case insensitive when using driver', () => {
+            expect(isUnknownError({
+                message: 'unknown error'
+            })).to.be.equal(true)
+
+            expect(isUnknownError({
+                message: 'UNKNOWN ERROR'
             })).to.be.equal(true)
         })
     })


### PR DESCRIPTION
## Proposed changes

[//]: # (Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.)
This PR will fix https://github.com/webdriverio/webdriverio/issues/3143

MicrosoftWebdriver (which powers edge) will return back "Unknown Command" if it receives a JSON Wire Protocol command while running in W3C Mode (which is now default in recent Windows 10 Releases).

This PR will allow the "Unknown Error" error to be retried.

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] I have proposed the same patch to the new [v5](https://github.com/webdriverio/v5) repository

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)
- I don't believe this is necessary in v5, as I think v5 uses w3c commands by default
- It would be really nice to refine the conditional to (psuedocode) `if (isUnknownError(err) && Browser == "Edge")`, but I'm not sure how to detect the browser in this piece of code

### Reviewers: @christian-bromann
