### PR TITLE
Change locator strategy of hash (#) to css selector instead of id

### DIFF
--- a/lib/helpers/findElementStrategy.js
+++ b/lib/helpers/findElementStrategy.js
@@ -36,11 +36,10 @@ let findStrategy = function (...args) {
     }
 
     // check value type
-    // use id strategy if value starts with # and doesnt contain any other CSS selector-relevant character
-    // regex to match ids from http://stackoverflow.com/questions/18938390/regex-to-match-ids-in-a-css-file
+    // use css selector for hash instead of by.id
+    // https://github.com/webdriverio/webdriverio/issues/2780
     if (value.search(/^#-?[_a-zA-Z]+[_a-zA-Z0-9-]*$/) > -1) {
-        using = 'id'
-        value = value.slice(1)
+        using = 'css selector'
 
     // use xPath strategy if value starts with //
     } else if (value.indexOf('/') === 0 || value.indexOf('(') === 0 ||

--- a/test/spec/unit/selectors.js
+++ b/test/spec/unit/selectors.js
@@ -9,8 +9,8 @@ describe('selector strategies helper', () => {
 
     it('should find an element using "id" method', () => {
         const element = findStrategy('#purplebox')
-        element.using.should.be.equal('id')
-        element.value.should.be.equal('purplebox')
+        element.using.should.be.equal('css selector')
+        element.value.should.be.equal('#purplebox')
     })
 
     it('should find an element using "name" method', () => {


### PR DESCRIPTION
## Proposed changes

[//]: # This change addresses issue [2780](https://github.com/webdriverio/webdriverio/issues/2780) where By.id location strategy is being removed since it is not part of the w3c spec.   With hash ```#``` already working for css selectors, this should be a transparent change to existing tests

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
- [ ] I have proposed the same patch to the new [v5](https://github.com/webdriverio/v5) repository

## Further comments

[//]: # (If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...)

### Reviewers: @christian-bromann
