### PR TITLE
Add ability to override default sauce selenium backend url

### DIFF
--- a/lib/helpers/detectSeleniumBackend.js
+++ b/lib/helpers/detectSeleniumBackend.js
@@ -65,7 +65,7 @@ let detectSeleniumBackend = function (capabilities) {
      */
     return {
         protocol: 'https',
-        host: `ondemand.${getSauceEndpoint(capabilities.region)}`,
+        host: capabilities.host || "ondemand.${getSauceEndpoint(capabilities.region)}",
         port: 443
     }
 }


### PR DESCRIPTION
## Proposed changes

[//]: #  Change allows caps.host to override saucelabs url for use with sauce-headless-beta

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
```
user: 'user',
    key: 'xxxxyoursuace-or-betakeyxxx',
    host: 'ondemand.us-east1.headless.saucelabs.com',
    maxInstances: 100,
    capabilities: [
        {
            browserName: 'chrome',
            browserVersion: 'latest',
            platform: 'linux'
        },
        // {
        //     browserName: 'firefox',
        //     browserVersion: 'latest',
        //     platform: 'linux'
        // },
    ],
```
the host value if presnt in caps will now overide the default selenium saucelabs url
[//]: # (_Put an `x` in the boxes that apply_)

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x ] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ x] I have added necessary documentation (if appropriate)
- [x ] I have proposed the same patch to the new [v5](https://github.com/webdriverio/v5) repository
will do soon ^
## Further comments

[//]: # 

Test by adding the host parameter to sauce capabilities, when set it should override the default, if not set, the default will still be used

### Reviewers: @christian-bromann
