### PR TITLE
Support for direct use of IE Webdriver with v4x

### DIFF
--- a/lib/helpers/utilities.js
+++ b/lib/helpers/utilities.js
@@ -53,7 +53,8 @@ export function isUnknownCommand (err) {
     /**
      * when running browser driver directly
      */
-    if (err.message.match(/Invalid Command Method/) ||
+    if (err.message.match(/Command not found/) ||
+        err.message.match(/Invalid Command Method/) ||
         err.message.match(/did not match a known command/) ||
         err.message.match(/unknown command/) ||
         err.message.match(/Driver info: driver\.version: unknown/) ||

--- a/lib/utils/RequestHandler.js
+++ b/lib/utils/RequestHandler.js
@@ -5,7 +5,7 @@ import request from 'request'
 import merge from 'deepmerge'
 
 import { ERROR_CODES } from '../helpers/constants'
-import { isSuccessfulResponse, formatHostname } from '../helpers/utilities'
+import { isSuccessfulResponse, formatHostname, isUnknownCommand } from '../helpers/utilities'
 import { RuntimeError } from './ErrorHandler'
 import pkg from '../../package.json'
 
@@ -253,6 +253,16 @@ class RequestHandler {
                     }
 
                     return reject(new RuntimeError(error))
+                }
+
+                // IEServer webdriver bug where the error is put into the Allow header
+                // https://github.com/SeleniumHQ/selenium/issues/6828
+                if (response && response.statusCode === 405) {
+                    let allowHeader = response.headers && response.headers.allow
+                    let err = new RuntimeError(allowHeader)
+                    if (isUnknownCommand(err)) {
+                        return reject(err)
+                    }
                 }
 
                 if (retryCount >= totalRetryCount) {

--- a/test/spec/unit/utilities.js
+++ b/test/spec/unit/utilities.js
@@ -87,6 +87,10 @@ describe('utilities', () => {
             expect(isUnknownCommand({
                 message: 'POST /session/foobar/keys did not match a known command'
             })).to.be.equal(true)
+
+            expect(isUnknownCommand({
+                message: 'Command not found: ...'
+            })).to.be.equal(true)
         })
 
         it('should recognise unknown command when using selenium standalone', () => {


### PR DESCRIPTION
## Proposed changes

IE immediately exits when a webdriver execute command is sent from wdio v4x. The problem is that the IE driver has a bug where the error is put into the Allow header [see the issue here](
https://github.com/SeleniumHQ/selenium/issues/6828). As in [this v5 pr](
https://github.com/webdriverio/webdriverio/pull/2846) I would like to work around the issue by acknowledging the error and trying to fall back to the old protocol. 

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have proposed the same patch to the new [v5](https://github.com/webdriverio/v5) repository

### Reviewers: @christian-bromann