### PR TITLE
Interpolate fallback host string in detectSeleniumBackend.js

### DIFF
--- a/lib/commands/setCookie.js
+++ b/lib/commands/setCookie.js
@@ -32,7 +32,7 @@
 import { CommandError } from '../utils/ErrorHandler'
 
 let setCookie = function (cookieObj) {
-    const { name } = cookieObj;
+    const { name } = cookieObj
     /*!
      * parameter check
      */

--- a/lib/helpers/detectSeleniumBackend.js
+++ b/lib/helpers/detectSeleniumBackend.js
@@ -65,7 +65,7 @@ let detectSeleniumBackend = function (capabilities) {
      */
     return {
         protocol: 'https',
-        host: capabilities.host || "ondemand.${getSauceEndpoint(capabilities.region)}",
+        host: capabilities.host || `ondemand.${getSauceEndpoint(capabilities.region)}`,
         port: 443
     }
 }

--- a/test/spec/cookie.js
+++ b/test/spec/cookie.js
@@ -1,8 +1,8 @@
 describe('cookie command test', () => {
-    afterEach(async function() {
+    afterEach(async function () {
         // Clear cookies after each test
-        await this.client.deleteCookie();
-    });
+        await this.client.deleteCookie()
+    })
 
     it('setCookie should fail if user provides name that is not a string type', async function () {
         try {
@@ -12,7 +12,7 @@ describe('cookie command test', () => {
             const cookies = await this.client.getCookie()
             cookies.should.have.length(0) // should never happen.
         } catch (e) {
-            (e.message).should.be.equal('Please specify a cookie object to set (see https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#cookie-json-object for documentation.');   
+            (e.message).should.be.equal('Please specify a cookie object to set (see https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#cookie-json-object for documentation.')
         }
     })
 
@@ -20,11 +20,11 @@ describe('cookie command test', () => {
         try {
             await this.client.setCookie('not appropriate')
             await this.client.setCookie({name: 'test2', value: 'cookie saved2!', domain: '127.0.0.1'})
-            
+
             const cookies = await this.client.getCookie()
             cookies.should.have.length(0) // should never happen.
         } catch (e) {
-            (e.message).should.be.equal('Please specify a cookie object to set (see https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#cookie-json-object for documentation.');   
+            (e.message).should.be.equal('Please specify a cookie object to set (see https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#cookie-json-object for documentation.')
         }
     })
 
@@ -32,11 +32,11 @@ describe('cookie command test', () => {
         try {
             await this.client.setCookie({value: 'cookie saved2!', domain: '127.0.0.1'})
             await this.client.setCookie({name: 'test2', value: 'cookie saved2!', domain: '127.0.0.1'})
-            
+
             const cookies = await this.client.getCookie()
             cookies.should.have.length(0) // should never happen.
         } catch (e) {
-            (e.message).should.be.equal('Please specify a cookie object to set (see https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#cookie-json-object for documentation.');   
+            (e.message).should.be.equal('Please specify a cookie object to set (see https://github.com/SeleniumHQ/selenium/wiki/JsonWireProtocol#cookie-json-object for documentation.')
         }
     })
 
@@ -75,7 +75,7 @@ describe('cookie command test', () => {
         const cookie = await this.client.getCookie("~!@#$%^&*()_+-={}|[]\:\"'<>?,./")
         cookie.should.be.an.instanceOf(Object)
         cookie.value.should.be.equal('cookie saved!')
-        
+
         cookie.name.should.be.equal("~!%2540%2523%2524%2525%255E%2526*()_%252B-%253D%257B%257D%257C%255B%255D%253A%2522'%253C%253E%253F%252C.%252F")
     })
 
@@ -155,5 +155,4 @@ describe('cookie command test', () => {
         (await this.client.getCookie("~!@#$%^&*()_+-={}|[]\:\"'<>?,./") === null).should.be.equal(true);
         (await this.client.getCookie()).should.have.length(1)
     })
-
 })

--- a/test/spec/unit/detectSeleniumBackend.js
+++ b/test/spec/unit/detectSeleniumBackend.js
@@ -42,14 +42,37 @@ describe('WebdriverIO detects Selenium backend', () => {
         caps.host.should.be.deep.equal('hub.testingbot.com')
         caps.port.should.be.deep.equal(80)
     })
-
-    it('should detect saucelabs user', () => {
-        const caps = detectSeleniumBackend({
+    describe('when provided with saucalabs credentials', () => {
+        const saucelabsCredentials = {
             user: 'foobar',
             key: '50aa152c-1932-B2f0-9707-18z46q2n1mb0'
+        }
+
+        it('should detect saucelabs user', () => {
+            const caps = detectSeleniumBackend(saucelabsCredentials)
+            caps.host.should.be.deep.equal('ondemand.saucelabs.com')
+            caps.port.should.be.deep.equal(443)
+            caps.protocol.should.be.deep.equal('https')
         })
-        caps.host.should.be.deep.equal('ondemand.saucelabs.com')
-        caps.port.should.be.deep.equal(443)
-        caps.protocol.should.be.deep.equal('https')
+
+        it('should set correct host value for "eu" region', () => {
+            const caps = detectSeleniumBackend({
+                ...saucelabsCredentials,
+                region: 'eu'
+            })
+            caps.host.should.be.deep.equal('ondemand.eu-central-1.saucelabs.com')
+            caps.port.should.be.deep.equal(443)
+            caps.protocol.should.be.deep.equal('https')
+        })
+
+        it('should allow specifyinig a custom region', () => {
+            const caps = detectSeleniumBackend({
+                ...saucelabsCredentials,
+                region: 'foo-1'
+            })
+            caps.host.should.be.deep.equal('ondemand.foo-1.saucelabs.com')
+            caps.port.should.be.deep.equal(443)
+            caps.protocol.should.be.deep.equal('https')
+        })
     })
 })

--- a/test/spec/unit/detectSeleniumBackend.js
+++ b/test/spec/unit/detectSeleniumBackend.js
@@ -42,7 +42,7 @@ describe('WebdriverIO detects Selenium backend', () => {
         caps.host.should.be.deep.equal('hub.testingbot.com')
         caps.port.should.be.deep.equal(80)
     })
-    describe('when provided with saucalabs credentials', () => {
+    describe('when provided with saucelabs credentials', () => {
         const saucelabsCredentials = {
             user: 'foobar',
             key: '50aa152c-1932-B2f0-9707-18z46q2n1mb0'

--- a/test/spec/unit/detectSeleniumBackend.js
+++ b/test/spec/unit/detectSeleniumBackend.js
@@ -65,7 +65,7 @@ describe('WebdriverIO detects Selenium backend', () => {
             caps.protocol.should.be.deep.equal('https')
         })
 
-        it('should allow specifyinig a custom region', () => {
+        it('should allow specifying a custom region', () => {
             const caps = detectSeleniumBackend({
                 ...saucelabsCredentials,
                 region: 'foo-1'


### PR DESCRIPTION
## Proposed changes
Fix #27, a bug introduced in PR #9 whereby connecting to saucelabs would fail with a `ERROR: getaddrinfo ENOTFOUND ondemand. ondemand.:443`. Upon some investigation, it turned out that this would happen if a `host` value was not specified in the config. After finding the code, it appears to be a simple issue of not interpolating the fallback string.

Fixed some linting issues, too (the ones that could be fixed automatically).

## Types of changes

[//]: # (What types of changes does your code introduce to WebdriverIO?)
[//]: # (_Put an `x` in the boxes that apply_)

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

[//]: # (_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._)

- [x] I have read the [CONTRIBUTING](https://github.com/webdriverio/webdriverio/blob/master/CONTRIBUTING.md) doc
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] I have proposed the same patch to the new [v5](https://github.com/webdriverio/v5) repository

## Further comments

I confirmed that this change fixes the relevant unit tests and does not break any additional tests (note that I couldn't get the project's tests to all pass on my machine).
Also added two unit tests for providing `region` config.

Minor update: I had a look at the v5 code and confirmed that this issue doesn't affect the current up-to-date-version.

### Reviewers: @christian-bromann
